### PR TITLE
Add ability to hide toc

### DIFF
--- a/about-repository/repertoire.rst
+++ b/about-repository/repertoire.rst
@@ -1,5 +1,5 @@
 :sequential_nav: both
-:hide_toc: true
+:hide-toc:
 
 ===============================================
 Repertoire

--- a/vanilla/page.html
+++ b/vanilla/page.html
@@ -2,7 +2,7 @@
 
 {% if meta %}
   {% set sequential_nav = meta.sequential_nav %}
-  {% set hide_toc = meta.hide_toc %}
+  {% set hide_toc = "hide-toc" in meta %}
 {% endif %}
 
 {% block body -%}
@@ -66,7 +66,7 @@
           </div>
         </div>
       </div>
-      {% if hide_toc=="true" %}
+      {% if hide_toc %}
       <main class="col-8">
       {% else %}
       <main class="col-7">
@@ -142,7 +142,7 @@
           {% endblock footer %}
         </footer>
       </main>
-      {% if not hide_toc=="true" %}
+      {% if not hide_toc %}
       <div class="col-3">
         <aside class="p-side-navigation--raw-html is-sticky">
           {% block right_sidebar %}


### PR DESCRIPTION
## Done

- Added ability to hide TOC by specifying `:hide_toc: true` at the top of the `.rst` file you want to hide it

## QA

- Checkout this branch and run `make run`
- Go to `http://0.0.0.0:8000/` and check the TOC is visible on RHS
- Go to `http://0.0.0.0:8000/about-repository/repertoire/` and check TOC is no longer visible 