### PR TITLE
fix handling of :sequential_nav: prev

### DIFF
--- a/vanilla/page.html
+++ b/vanilla/page.html
@@ -89,6 +89,7 @@
                         {{ prev.title }}
                         {% endif %}
                     </span>
+                  </a>
                 {%- endif %}
               {% endif %}
 


### PR DESCRIPTION
The <a> tag wasn't closed, which lead to the browser duplicating
parts of the link to the previous topic.

Signed-off-by: Ruth Fuchss <ruth.fuchss@canonical.com>