### PR TITLE
Add an optional "Edit on GitHub" link

### DIFF
--- a/vanilla/page.html
+++ b/vanilla/page.html
@@ -138,6 +138,10 @@
                 {{ _('Show Source') }}
               </a>
             {%- endif %}
+            {% if github_url and github_version and github_folder and github_filetype %}
+              {%- if show_copyright or last_updated or show_sphinx or show_source %} | {%- endif %}
+              <a href="{{ github_url }}/edit/{{ github_version }}{{ github_folder }}{{ pagename }}.{{ github_filetype }}">Edit on GitHub</a>
+            {% endif %}
           </div>
           {% endblock footer %}
         </footer>


### PR DESCRIPTION
With this change, an "Edit on GitHub" link can be added to the
footer by specifying options like the following in the conf.py
file:

html_context = {
    "github_url": "https://github.com/lxc/lxd",
    "github_version": "master",
    "github_folder": "/doc/",
    "github_filetype": "md"
}

If any of the options are missing, nothing is added to the footer.

Signed-off-by: Ruth Fuchss <ruth.fuchss@canonical.com>