### PR TITLE
allow setting a default value for sequential_nav

### DIFF
--- a/vanilla/page.html
+++ b/vanilla/page.html
@@ -1,7 +1,9 @@
 {% extends "base.html" %}
 
 {% if meta %}
-  {% set sequential_nav = meta.sequential_nav %}
+  {% if 'sequential_nav' in meta %}
+    {% set sequential_nav = meta.sequential_nav %}
+  {% endif %}
   {% set hide_toc = "hide-toc" in meta %}
 {% endif %}
 


### PR DESCRIPTION
This change makes it possible to set a default value for
sequential nav in the html_context variable in conf.py,
and at the same time override the setting in the metadata
for each file.

Signed-off-by: Ruth Fuchss <ruth.fuchss@canonical.com>