### PR TITLE
Move header to a separate file

### DIFF
--- a/vanilla/header.html
+++ b/vanilla/header.html
@@ -1,0 +1,33 @@
+{% block header -%}
+<header id="navigation" class="p-navigation is-dark">
+  <div class="p-navigation__row">
+    <div class="p-navigation__banner">
+      <div class="p-navigation__logo">
+        <a class="p-navigation__item" href="{{ pathto(master_doc) }}">
+          <img class="p-navigation__image" src="https://assets.ubuntu.com/v1/3c7954dd-logo-canonical-white.svg" alt="{{ docstitle }}" width="95">
+        </a>
+      </div>
+      <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>
+      <a href="#navigation-closed" class="p-navigation__toggle--close" title="close menu">Close menu</a>
+    </div>
+    {% block headernav -%}
+    <nav class="p-navigation__nav" aria-label="Example main navigation">
+      <ul class="p-navigation__items">
+        <li class="p-navigation__item is-selected">
+          <a class="p-navigation__link" href="#">Products</a>
+        </li>
+        <li class="p-navigation__item">
+          <a class="p-navigation__link" href="#">Services</a>
+        </li>
+        <li class="p-navigation__item">
+          <a class="p-navigation__link" href="#">Partners</a>
+        </li>
+        <li class="p-navigation__item">
+          <a class="p-navigation__link" href="#">About</a>
+        </li>
+      </ul>
+    </nav>
+    {% endblock headernav %}
+  </div>
+</header>
+{% endblock header %}

--- a/vanilla/page.html
+++ b/vanilla/page.html
@@ -6,35 +6,9 @@
 {% endif %}
 
 {% block body -%}
-  <header id="navigation" class="p-navigation is-dark">
-    <div class="p-navigation__row">
-      <div class="p-navigation__banner">
-        <div class="p-navigation__logo">
-          <a class="p-navigation__item" href="{{ pathto(master_doc) }}">
-            <img class="p-navigation__image" src="https://assets.ubuntu.com/v1/3c7954dd-logo-canonical-white.svg" alt="{{ docstitle }}" width="95">
-          </a>
-        </div>
-        <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>
-        <a href="#navigation-closed" class="p-navigation__toggle--close" title="close menu">Close menu</a>
-      </div>
-      <nav class="p-navigation__nav" aria-label="Example main navigation">
-        <ul class="p-navigation__items">
-          <li class="p-navigation__item is-selected">
-            <a class="p-navigation__link" href="#">Products</a>
-          </li>
-          <li class="p-navigation__item">
-            <a class="p-navigation__link" href="#">Services</a>
-          </li>
-          <li class="p-navigation__item">
-            <a class="p-navigation__link" href="#">Partners</a>
-          </li>
-          <li class="p-navigation__item">
-            <a class="p-navigation__link" href="#">About</a>
-          </li>
-        </ul>
-      </nav>
-    </div>
-  </header>
+
+  {% include "header.html" %}
+
   <section class="p-strip--light is-shallow">
     <div class="u-fixed-width">
       <form class="p-search-box u-no-margin--bottom">


### PR DESCRIPTION
Move the HTML header to a separate file, which makes it easier
to override when using the theme.
This should just be a first step in making the header replaceable.

Signed-off-by: Ruth Fuchss <ruth.fuchss@canonical.com>