### PR TITLE
Fix that allows external favicons

### DIFF
--- a/vanilla/base.html
+++ b/vanilla/base.html
@@ -29,8 +29,8 @@
     {%- endblock linktags %}
 
     {# Favicon #}
-    {%- if favicon -%}
-      <link rel="shortcut icon" href="{{ pathto('_static/' + favicon, 1) }}"/>
+    {%- if favicon_url -%}
+      <link rel="shortcut icon" href="{{ favicon_url }}"/>
     {%- endif -%}
 
     {#- Generator banner -#}


### PR DESCRIPTION
Use favicon_url instead of favicon, as done in other themes.
Favicon_url already has the URL resolved for both absolute and
relative paths.

Signed-off-by: Ruth Fuchss <ruth.fuchss@canonical.com>